### PR TITLE
Generalizations of iSTOP

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Import:
     purrr,
     readr,
     stringr,
+    stringi,
     tibble,
     tidyr
 Suggests:

--- a/R/add-RFLP.R
+++ b/R/add-RFLP.R
@@ -44,6 +44,7 @@ add_RFLP <- function(iSTOP, recognizes = 'c', width = 150, enzymes = NULL, cores
 
       if (recognizes == 't') {
         search <- stringr::str_replace(search, 'c', 't')
+        search <- stringr::str_replace(search, 'g', 'a')
         column_name <- paste0('RFLP_T_', width)
       } else {
         column_name <- paste0('RFLP_C_', width)

--- a/R/add-RFLP.R
+++ b/R/add-RFLP.R
@@ -40,10 +40,10 @@ add_RFLP <- function(iSTOP, recognizes = 'c', width = 150, enzymes = NULL, cores
     pbapply::pblapply(function(df) {
 
       # Make sure c is in the search
-      search <- ifelse(str_detect(search, '[ATGC]c'), search, as.character(Biostrings::reverseComplement(Biostrings::DNAStringSet(search))))
+      search <- ifelse(str_detect(df$searched, '[ATGC]c'), df$searched, as.character(Biostrings::reverseComplement(Biostrings::DNAStringSet(df$searched))))
       if (any(!str_detect(search, 'c'))) warning('add_RFLP currently only supports searching of reference sequences that contain a "c" in either strand.')
       target <- str_locate('c')[,'start']
-      search <- stringr::str_sub(df$searched, start = target - width, end = target + width)
+      search <- stringr::str_sub(search, start = target - width, end = target + width)
 
       if (recognizes == 't') {
         search <- stringr::str_replace(search, 'c', 't')

--- a/R/add-RFLP.R
+++ b/R/add-RFLP.R
@@ -42,7 +42,7 @@ add_RFLP <- function(iSTOP, recognizes = 'c', width = 150, enzymes = NULL, cores
       # Make sure c is in the search
       search <- ifelse(str_detect(df$searched, '[ATGC]c'), df$searched, as.character(Biostrings::reverseComplement(Biostrings::DNAStringSet(df$searched))))
       if (any(!str_detect(search, 'c'))) warning('add_RFLP currently only supports searching of reference sequences that contain a "c" in either strand.')
-      target <- str_locate('c')[,'start']
+      target <- str_locate(search, 'c')[,'start']
       search <- stringr::str_sub(search, start = target - width, end = target + width)
 
       if (recognizes == 't') {

--- a/R/add-RFLP.R
+++ b/R/add-RFLP.R
@@ -40,7 +40,7 @@ add_RFLP <- function(iSTOP, recognizes = 'c', width = 150, enzymes = NULL, cores
     pbapply::pblapply(function(df) {
 
       # Make sure c is in the search
-      search <- ifelse(str_detect(df$searched, '[ATGC]c'), df$searched, as.character(Biostrings::reverseComplement(Biostrings::DNAStringSet(df$searched))))
+      search <- ifelse(str_detect(df$searched, '[ATGC]c'), df$searched, dna_reverse_complement(df$searched))
       if (any(!str_detect(search, 'c'))) warning('add_RFLP currently only supports searching of reference sequences that contain a "c" in either strand.')
       target <- str_locate(search, 'c')[,'start']
       search <- stringr::str_sub(search, start = target - width, end = target + width)
@@ -188,4 +188,11 @@ str_to_lower_each <- function(string, pattern, locale = 'en') {
   mid <- purrr::map2(string, loc, ~stringr::str_sub(.x, start = .y[, 'start'], end = .y[, 'end']) %>% stringr::str_to_lower(locale))
 
   purrr::pmap(list(lhs, mid, rhs), str_c)
+}
+
+# Reverse complement that preserves case
+dna_reverse_complement <- function(x, complement = c('ATGCYRSWKMBDHVN' = 'TACGRYSWMKVHDBN')) {
+  from <- paste0(names(complement), stringr::str_to_lower(names(complement)))
+  to   <- paste0(complement,        stringr::str_to_lower(complement))
+  chartr(from, to, stringi::stri_reverse(x))
 }

--- a/R/add-RFLP.R
+++ b/R/add-RFLP.R
@@ -39,12 +39,14 @@ add_RFLP <- function(iSTOP, recognizes = 'c', width = 150, enzymes = NULL, cores
     split(.$chr) %>%   # split on chromosome for parallelization
     pbapply::pblapply(function(df) {
 
-      center <- ceiling(stringr::str_length(df$searched) / 2)
-      search <- stringr::str_sub(df$searched, start = center - width, end = center + width)
+      # Make sure c is in the search
+      search <- ifelse(str_detect(search, '[ATGC]c'), search, Biostrings::reverseComplement(Biostrings::DNAStringSet(search)))
+      if (any(!str_detect(search, 'c'))) warning('add_RFLP currently only supports searching of reference sequences that contain a "c" in either strand.')
+      target <- str_locate('c')[,'start']
+      search <- stringr::str_sub(df$searched, start = target - width, end = target + width)
 
       if (recognizes == 't') {
         search <- stringr::str_replace(search, 'c', 't')
-        search <- stringr::str_replace(search, 'g', 'a')
         column_name <- paste0('RFLP_T_', width)
       } else {
         column_name <- paste0('RFLP_C_', width)

--- a/R/add-RFLP.R
+++ b/R/add-RFLP.R
@@ -40,7 +40,7 @@ add_RFLP <- function(iSTOP, recognizes = 'c', width = 150, enzymes = NULL, cores
     pbapply::pblapply(function(df) {
 
       # Make sure c is in the search
-      search <- ifelse(str_detect(search, '[ATGC]c'), search, Biostrings::reverseComplement(Biostrings::DNAStringSet(search)))
+      search <- ifelse(str_detect(search, '[ATGC]c'), search, as.character(Biostrings::reverseComplement(Biostrings::DNAStringSet(search))))
       if (any(!str_detect(search, 'c'))) warning('add_RFLP currently only supports searching of reference sequences that contain a "c" in either strand.')
       target <- str_locate('c')[,'start']
       search <- stringr::str_sub(df$searched, start = target - width, end = target + width)

--- a/R/get-genomic-sequence.R
+++ b/R/get-genomic-sequence.R
@@ -28,14 +28,18 @@ get_genomic_sequence <- function(at, add_5prime, add_3prime, genome, chr, strand
     all(strand %in% c('+', '-'))
   )
 
+  at         <- as.integer(round(at))
+  add_5prime <- as.integer(round(add_5prime))
+  add_3prime <- as.integer(round(add_3prime))
+
   if (length(strand) != length(at)) strand <- rep(strand, length(at))
 
   # Determine the boundaries of this chromosome
   max_coord <- GenomeInfoDb::seqlengths(genome)[chr]
 
   # Add to 'at' in 5' and 3' direction which depends on the strand
-  start <- purrr::map2_dbl(strand, at, ~switch(.x, '+' = .y - add_5prime, '-' = .y - add_3prime))
-  end   <- purrr::map2_dbl(strand, at, ~switch(.x, '+' = .y + add_3prime, '-' = .y + add_5prime))
+  start <- ifelse(strand == '+', at - add_5prime, at - add_3prime)
+  end   <- ifelse(strand == '+', at + add_3prime, at + add_5prime)
 
   # Start should always be smaller of the two
   st <- pmin(start, end)

--- a/R/locate-PAM.R
+++ b/R/locate-PAM.R
@@ -78,10 +78,10 @@ locate_PAM <- function(codons,
       # make targeted base lower case
       searched =  stringr::str_c(
         stringr::str_sub(searched, end   = flanking),                                                     # LHS
-        stringr::str_sub(searched, start = flanking + 1, end = flanking + 1) %>% stringr::str_to_lower(), # C -> c
+        stringr::str_sub(searched, start = flanking + 1, end = flanking + 1) %>% stringr::str_to_lower(), # target
         stringr::str_sub(searched, start = flanking + 2)                                                  # RHS
       ),
-      no_upstream_G = !str_detect(searched, 'Gc')
+      no_upstream_G = !str_detect(searched, 'G[tcga]')
     )
 
   # Add an sgSTOP column for each PAM
@@ -98,7 +98,7 @@ locate_PAM <- function(codons,
       guide_sequence <-
         coalesce(
           sequences[[col_name_guide]],
-          sgSTOP(sequences$searched, pattern = PAM[[i]]$pattern, base_edit = 'c', spacing = spacing[[j]], width = 20 + PAM[[i]]$width)
+          sgSTOP(sequences$searched, pattern = PAM[[i]]$pattern, base_edit = '[tcga]', spacing = spacing[[j]], width = 20 + PAM[[i]]$width)
         )
 
       guide_spacing <-


### PR DESCRIPTION
- Allow fully vectorized strand, at, and add parameters in `get_genomic_sequence`
- Fix strand bug in `add_RFLP` when `recognizes = 't'`
- Allow PAM pattern detection for bases other than C