### PR TITLE
Fix DESCRIPTION for smoother installation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Imports:
     BSgenome,
     Biostrings,
     dplyr,
+    fuzzyjoin,
     pbapply,
     purrr,
     readr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ VignetteBuilder: knitr
 RoxygenNote: 6.0.1
 biocViews: Software, Genetics
 Depends: R (>= 3.4)
-Import:
+Imports:
     assertthat,
     BSgenome,
     Biostrings,


### PR DESCRIPTION
Installation of iSTOP should now work with `remotes::install_github()` and `devtools::install_github()`.